### PR TITLE
Allows to redefine sluggable_type using Louisville::Util::polymorphic_name

### DIFF
--- a/lib/louisville/extensions/history.rb
+++ b/lib/louisville/extensions/history.rb
@@ -17,7 +17,9 @@ module Louisville
         base.class_eval do
 
           # provide an association for easy lookup, joining, etc.
-          has_many :historical_slugs, :class_name => 'Louisville::Slug', :dependent => :destroy, :as => :sluggable
+          has_many :historical_slugs, lambda { |klass|
+            where(sluggable_type: Louisville::Util::polymorphic_name(klass.class))
+          }, :class_name => 'Louisville::Slug', :dependent => :destroy, :foreign_key => :sluggable_id
 
           # If our slug has changed we should manage the history.
           after_save :delete_matching_historical_slug,  :if => :louisville_slug_changed?


### PR DESCRIPTION
It was not possible to override the `:has_many` relationship of historical slugs before, so it will always use the `class_name` of the class where we wanted to add the history of slugs.

Thus when having namespaces:

`Manager::User`, `Customer::User`, it was not allow storing just `User` as the sluggable_type thus  and `Manager::User.find('something')` would trigger the same query:

```
Manager::User.find('something') => 
SELECT `slugs`.* FROM `slugs`  WHERE `slugs`.`sluggable_id` = 1 AND `slugs`.`sluggable_type` = 'Manager::User'

Customer::User.find('something') => 
SELECT `slugs`.* FROM `slugs`  WHERE `slugs`.`sluggable_id` = 1 AND `slugs`.`sluggable_type` = 'Customer::User'

```
